### PR TITLE
Add Light Mode to Mobile App

### DIFF
--- a/mobile/lib/app/app.dart
+++ b/mobile/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:twoaxis_finance/app/theme.dart';
+import 'package:twoaxis_finance/app/theme_cubit.dart';
 import 'package:twoaxis_finance/features/app_shell/presentation/pages/app_shell.dart';
 import 'package:twoaxis_finance/features/auth/data/auth_repository_impl.dart';
 import 'package:twoaxis_finance/features/auth/domain/auth_repository.dart';
@@ -57,6 +58,9 @@ class _AppState extends State<App> {
       child: MultiBlocProvider(
         providers: [
           BlocProvider(
+            create: (context) => ThemeCubit(),
+          ),
+          BlocProvider(
             create: (context) => UserCubit(
               authRepository: context.read<AuthRepository>(),
             ),
@@ -107,16 +111,25 @@ class _AppState extends State<App> {
             ),
           ),
         ],
-        child: MaterialApp(
-          debugShowCheckedModeBanner: false,
-          title: "TwoAxis Finance",
-          themeMode: ThemeMode.dark,
-          darkTheme: ThemeData(
-            splashFactory: NoSplash.splashFactory,
-            colorScheme: darkTheme,
-            useMaterial3: true,
-          ),
-          home: const AppShell(),
+        child: BlocBuilder<ThemeCubit, ThemeMode>(
+          builder: (context, mode) {
+            return MaterialApp(
+              debugShowCheckedModeBanner: false,
+              title: "TwoAxis Finance",
+              themeMode: mode,
+              theme: ThemeData(
+                splashFactory: NoSplash.splashFactory,
+                colorScheme: appLightTheme,
+                useMaterial3: true,
+              ),
+              darkTheme: ThemeData(
+                splashFactory: NoSplash.splashFactory,
+                colorScheme: appDarkTheme,
+                useMaterial3: true,
+              ),
+              home: const AppShell(),
+            );
+          },
         ),
       ),
     );

--- a/mobile/lib/app/theme.dart
+++ b/mobile/lib/app/theme.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-var darkTheme = const ColorScheme.dark(
+var appDarkTheme = const ColorScheme.dark(
   brightness: Brightness.dark,
   primary: Color.fromARGB(255, 167, 34, 34),
   primaryContainer: Color.fromARGB(255, 167, 34, 34),
@@ -13,4 +13,19 @@ var darkTheme = const ColorScheme.dark(
   surfaceBright: Color.fromARGB(255, 40, 40, 40),
   onSurfaceVariant: Color.fromARGB(255, 100, 100, 100),
   outline: Color.fromARGB(255, 100, 100, 100)
+);
+
+var appLightTheme = const ColorScheme.light(
+  brightness: Brightness.light,
+  primary: Color.fromARGB(255, 167, 34, 34),
+  primaryContainer: Color.fromARGB(255, 167, 34, 34),
+  onPrimary: Colors.white,
+  secondary: Color.fromARGB(255, 94, 25, 25),
+  secondaryContainer: Color.fromARGB(255, 94, 25, 25),
+  onSecondary: Colors.white,
+  surface: Colors.white,
+  surfaceContainer: Color.fromARGB(255, 240, 240, 240),
+  surfaceBright: Color.fromARGB(255, 250, 250, 250),
+  onSurfaceVariant: Color.fromARGB(255, 80, 80, 80),
+  outline: Color.fromARGB(255, 180, 180, 180)
 );

--- a/mobile/lib/app/theme_cubit.dart
+++ b/mobile/lib/app/theme_cubit.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ThemeCubit extends Cubit<ThemeMode> {
+  ThemeCubit() : super(ThemeMode.dark);
+
+  void toggleTheme(bool isDark) {
+    emit(isDark ? ThemeMode.dark : ThemeMode.light);
+  }
+}

--- a/mobile/lib/app/theme_cubit.dart
+++ b/mobile/lib/app/theme_cubit.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ThemeCubit extends Cubit<ThemeMode> {
-  ThemeCubit() : super(ThemeMode.dark);
+  ThemeCubit() : super(ThemeMode.dark) {
+    _loadTheme();
+  }
 
-  void toggleTheme(bool isDark) {
+  void _loadTheme() async {
+    var instance = await SharedPreferences.getInstance();
+    emit(instance.getBool('dark_mode') == true ? ThemeMode.dark : ThemeMode.light);
+  }
+
+  void toggleTheme(bool isDark) async {
+    var instance = await SharedPreferences.getInstance();
+    instance.setBool('dark_mode', isDark);
     emit(isDark ? ThemeMode.dark : ThemeMode.light);
   }
 }

--- a/mobile/lib/core/widgets/primary_button.dart
+++ b/mobile/lib/core/widgets/primary_button.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 
 class PrimaryButton extends StatelessWidget {
@@ -15,7 +14,7 @@ class PrimaryButton extends StatelessWidget {
       height: 50,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          backgroundColor: darkTheme.primary,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10),
           ),
@@ -27,7 +26,7 @@ class PrimaryButton extends StatelessWidget {
         } : null,
         child: Text(
           text,
-          style: TextStyle(color: darkTheme.onPrimary),
+          style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
         ),
       ),
     );

--- a/mobile/lib/core/widgets/themed_input_field.dart
+++ b/mobile/lib/core/widgets/themed_input_field.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 
 class ThemedInputField extends StatelessWidget {
@@ -45,7 +44,7 @@ class ThemedInputField extends StatelessWidget {
           decoration: InputDecoration(
             filled: true,
             hintText: placeholder,
-            fillColor: darkTheme.surfaceContainer,
+            fillColor: Theme.of(context).colorScheme.surfaceContainer,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(10),
               borderSide: BorderSide.none,

--- a/mobile/lib/features/account/presentation/pages/account.dart
+++ b/mobile/lib/features/account/presentation/pages/account.dart
@@ -1,10 +1,10 @@
 import 'package:twoaxis_finance/features/account/presentation/pages/account_currency.dart';
 import 'package:twoaxis_finance/features/account/presentation/pages/account_settings.dart';
+import 'package:twoaxis_finance/app/theme_cubit.dart';
 import 'package:twoaxis_finance/features/auth/domain/auth_repository.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
 import 'package:twoaxis_finance/features/info/presentation/pages/info.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -34,9 +34,9 @@ class AccountPage extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
-                      color: darkTheme.surfaceContainer,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       gradient: LinearGradient(
-                        colors: [darkTheme.primary, darkTheme.secondary],
+                        colors: [Theme.of(context).colorScheme.primary, Theme.of(context).colorScheme.secondary],
                       ),
                       borderRadius: const BorderRadius.all(Radius.circular(10))),
                   child: Row(
@@ -105,7 +105,7 @@ class AccountPage extends StatelessWidget {
                 ),
                 Container(
                   decoration: BoxDecoration(
-                    color: darkTheme.surfaceBright,
+                    color: Theme.of(context).colorScheme.surfaceBright,
                     borderRadius: const BorderRadius.all(Radius.circular(10)),
                   ),
                   child: Column(
@@ -126,7 +126,7 @@ class AccountPage extends StatelessWidget {
                         ),
                       ),
                       Divider(
-                        color: darkTheme.surface,
+                        color: Theme.of(context).colorScheme.surface,
                         height: 1,
                         thickness: 3,
                       ),
@@ -146,7 +146,7 @@ class AccountPage extends StatelessWidget {
                         ),
                       ),
                       Divider(
-                        color: darkTheme.surface,
+                        color: Theme.of(context).colorScheme.surface,
                         height: 1,
                         thickness: 3,
                       ),
@@ -165,6 +165,27 @@ class AccountPage extends StatelessWidget {
                           child: const Text("Currency"),
                         ),
                       ),
+                      Divider(
+                        color: Theme.of(context).colorScheme.surface,
+                        height: 1,
+                        thickness: 3,
+                      ),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text("Dark Mode"),
+                            Switch(
+                              value: context.read<ThemeCubit>().state == ThemeMode.dark,
+                              onChanged: (val) {
+                                context.read<ThemeCubit>().toggleTheme(val);
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -179,7 +200,7 @@ class AccountPage extends StatelessWidget {
                     width: double.infinity,
                     padding: const EdgeInsets.all(15),
                     decoration: BoxDecoration(
-                      color: darkTheme.surfaceBright,
+                      color: Theme.of(context).colorScheme.surfaceBright,
                       borderRadius: const BorderRadius.all(Radius.circular(10)),
                     ),
                     child: const Text(
@@ -197,7 +218,7 @@ class AccountPage extends StatelessWidget {
                     Text(
                       "(c) ${DateTime.now().year} TwoAxis. All Rights Reserved.",
                       textAlign: TextAlign.center,
-                      style: TextStyle(color: darkTheme.onSurfaceVariant),
+                      style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
                     ),
                   ],
                 ),

--- a/mobile/lib/features/account/presentation/pages/account.dart
+++ b/mobile/lib/features/account/presentation/pages/account.dart
@@ -36,9 +36,13 @@ class AccountPage extends StatelessWidget {
                   decoration: BoxDecoration(
                       color: Theme.of(context).colorScheme.surfaceContainer,
                       gradient: LinearGradient(
-                        colors: [Theme.of(context).colorScheme.primary, Theme.of(context).colorScheme.secondary],
+                        colors: [
+                          Theme.of(context).colorScheme.primary,
+                          Theme.of(context).colorScheme.secondary
+                        ],
                       ),
-                      borderRadius: const BorderRadius.all(Radius.circular(10))),
+                      borderRadius:
+                          const BorderRadius.all(Radius.circular(10))),
                   child: Row(
                     spacing: 10,
                     children: [
@@ -68,12 +72,20 @@ class AccountPage extends StatelessWidget {
                             },
                             errorBuilder: (BuildContext context, Object error,
                                 StackTrace? stackTrace) {
-                              return const Icon(Icons.person, size: 60);
+                              return Icon(
+                                Icons.person,
+                                size: 60,
+                                color: Theme.of(context).colorScheme.onPrimary,
+                              );
                             },
                           ),
                         )
                       else
-                        const Icon(Icons.person, size: 60),
+                        Icon(
+                          Icons.person,
+                          size: 60,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
                       Flexible(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
@@ -81,19 +93,30 @@ class AccountPage extends StatelessWidget {
                             if (user.name.isNotEmpty)
                               Text(
                                 user.name,
-                                style: const TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 24),
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 24,
+                                  color:
+                                      Theme.of(context).colorScheme.onPrimary,
+                                ),
                               )
                             else
-                              const Text(
+                              Text(
                                 "No display name",
                                 style: TextStyle(
-                                    fontWeight: FontWeight.normal,
-                                    fontSize: 24,
-                                    fontStyle: FontStyle.italic),
+                                  fontWeight: FontWeight.normal,
+                                  fontSize: 24,
+                                  fontStyle: FontStyle.italic,
+                                  color:
+                                      Theme.of(context).colorScheme.onPrimary,
+                                ),
                               ),
-                            Text(user.email)
+                            Text(
+                              user.email,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.onPrimary,
+                              ),
+                            )
                           ],
                         ),
                       )
@@ -105,7 +128,7 @@ class AccountPage extends StatelessWidget {
                 ),
                 Container(
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surfaceBright,
+                    color: Theme.of(context).colorScheme.surfaceContainer,
                     borderRadius: const BorderRadius.all(Radius.circular(10)),
                   ),
                   child: Column(
@@ -172,13 +195,15 @@ class AccountPage extends StatelessWidget {
                       ),
                       Container(
                         width: double.infinity,
-                        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 15, vertical: 5),
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             const Text("Dark Mode"),
                             Switch(
-                              value: context.read<ThemeCubit>().state == ThemeMode.dark,
+                              value: context.read<ThemeCubit>().state ==
+                                  ThemeMode.dark,
                               onChanged: (val) {
                                 context.read<ThemeCubit>().toggleTheme(val);
                               },
@@ -200,7 +225,7 @@ class AccountPage extends StatelessWidget {
                     width: double.infinity,
                     padding: const EdgeInsets.all(15),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surfaceBright,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       borderRadius: const BorderRadius.all(Radius.circular(10)),
                     ),
                     child: const Text(
@@ -218,7 +243,9 @@ class AccountPage extends StatelessWidget {
                     Text(
                       "(c) ${DateTime.now().year} TwoAxis. All Rights Reserved.",
                       textAlign: TextAlign.center,
-                      style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                      style: TextStyle(
+                          color:
+                              Theme.of(context).colorScheme.onSurfaceVariant),
                     ),
                   ],
                 ),

--- a/mobile/lib/features/account/presentation/pages/account_currency.dart
+++ b/mobile/lib/features/account/presentation/pages/account_currency.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/features/account/presentation/bloc/account_bloc.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
@@ -62,7 +61,7 @@ class AccountCurrency extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Select Currency'),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       ),
       body: BlocBuilder<UserCubit, UserState>(
         builder: (context, state) {
@@ -76,7 +75,7 @@ class AccountCurrency extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 8),
             itemCount: currencies.length,
             separatorBuilder: (_, __) => Divider(
-              color: darkTheme.surfaceContainer, height: 1),
+              color: Theme.of(context).colorScheme.surfaceContainer, height: 1),
             itemBuilder: (context, index) {
               var code = currencies.keys.elementAt(index);
               var name = currencies[code]!;

--- a/mobile/lib/features/account/presentation/pages/account_settings.dart
+++ b/mobile/lib/features/account/presentation/pages/account_settings.dart
@@ -7,7 +7,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
 
@@ -59,7 +58,7 @@ class _AccountSettingsState extends State<AccountSettings> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text("Account settings"),
-          backgroundColor: darkTheme.surfaceContainer,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         ),
         body: SafeArea(
           child: Padding(

--- a/mobile/lib/features/analytics/presentation/pages/analytics.dart
+++ b/mobile/lib/features/analytics/presentation/pages/analytics.dart
@@ -8,7 +8,6 @@ import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart'
 import 'package:twoaxis_finance/features/transactions/presentation/bloc/transactions_bloc.dart';
 import 'package:twoaxis_finance/features/transactions/domain/transaction_type.dart';
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class AnalyticsPage extends StatelessWidget {
   const AnalyticsPage({super.key});
@@ -49,7 +48,7 @@ class AnalyticsPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text("Analytics"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       ),
       body: SafeArea(
         child: Padding(
@@ -86,7 +85,7 @@ class AnalyticsPage extends StatelessWidget {
                         ),
                         SizedBox(height: 20),
                         Divider(
-                          color: darkTheme.surfaceBright,
+                          color: Theme.of(context).colorScheme.surfaceBright,
                         ),
                         SizedBox(height: 20),
                         Row(
@@ -102,7 +101,7 @@ class AnalyticsPage extends StatelessWidget {
                         ),
                         SizedBox(height: 20),
                         Divider(
-                          color: darkTheme.surfaceBright,
+                          color: Theme.of(context).colorScheme.surfaceBright,
                         ),
                         SizedBox(height: 20),
                         Row(
@@ -118,7 +117,7 @@ class AnalyticsPage extends StatelessWidget {
                         ),
                         SizedBox(height: 20),
                         Divider(
-                          color: darkTheme.surfaceBright,
+                          color: Theme.of(context).colorScheme.surfaceBright,
                         ),
                         SizedBox(height: 20),
                         Row(
@@ -194,20 +193,20 @@ class AnalyticsPage extends StatelessWidget {
                                   LineChartBarData(
                                     spots: spots,
                                     gradient: LinearGradient(
-                                      colors: [darkTheme.primary, darkTheme.secondary],
+                                      colors: [Theme.of(context).colorScheme.primary, Theme.of(context).colorScheme.secondary],
                                     ),
                                     barWidth: 5,
                                     belowBarData: BarAreaData(
                                       show: true,
                                       gradient: LinearGradient(
-                                        colors: [darkTheme.primary, darkTheme.secondary]
+                                        colors: [Theme.of(context).colorScheme.primary, Theme.of(context).colorScheme.secondary]
                                             .map((color) => color.withAlpha(77))
                                             .toList(),
                                       ),
                                     ),
                                   ),
                                 ],
-                                backgroundColor: darkTheme.surfaceContainer),
+                                backgroundColor: Theme.of(context).colorScheme.surfaceContainer),
                           ),
                         );
                       },

--- a/mobile/lib/features/app_shell/presentation/widgets/navbar.dart
+++ b/mobile/lib/features/app_shell/presentation/widgets/navbar.dart
@@ -27,7 +27,7 @@ class Navbar extends StatelessWidget {
         showUnselectedLabels: true,
         selectedItemColor: Theme.of(context).colorScheme.primary,
         type: BottomNavigationBarType.fixed,
-        unselectedItemColor: Color(0x44FFFFFF),
+        unselectedItemColor: Theme.of(context).colorScheme.onSurfaceVariant,
         onTap: onTap,
         items: [
           BottomNavigationBarItem(

--- a/mobile/lib/features/assets/presentation/pages/assets.dart
+++ b/mobile/lib/features/assets/presentation/pages/assets.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/assets/presentation/bloc/assets_bloc.da
 import 'package:twoaxis_finance/features/assets/presentation/widgets/asset_action_button.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,7 +20,7 @@ class _AssetsPageState extends State<AssetsPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Assets"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [AssetActionButton()],
       ),
       body: Column(
@@ -82,7 +81,7 @@ class _AssetsPageState extends State<AssetsPage> {
                             child: Text(
                               formatMoneyWithContext(context, item.value),
                               style: TextStyle(
-                                color: darkTheme.surfaceTint,
+                                color: Theme.of(context).colorScheme.surfaceTint,
                                 fontSize: 15,
                               ),
                             ),
@@ -130,7 +129,7 @@ class _AssetsPageState extends State<AssetsPage> {
                   );
                 },
                 separatorBuilder: (BuildContext context, int index) {
-                  return Divider(color: darkTheme.surfaceContainer, height: 1);
+                  return Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                 },
               );
             }),

--- a/mobile/lib/features/auth/presentation/pages/email_sent.dart
+++ b/mobile/lib/features/auth/presentation/pages/email_sent.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
@@ -27,7 +26,7 @@ class EmailSent extends StatelessWidget {
                 'Email has been sent',
                 style: TextStyle(
                   fontSize: 30,
-                  color: darkTheme.onPrimary,
+                  color: Theme.of(context).colorScheme.onPrimary,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -35,7 +34,7 @@ class EmailSent extends StatelessWidget {
                 textAlign: TextAlign.center,
                 'Make sure to check your spam or junk folder.',
                 style: TextStyle(
-                  color: darkTheme.onSurfaceVariant,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                   fontSize: 20,
                 ),
               ),

--- a/mobile/lib/features/auth/presentation/pages/login.dart
+++ b/mobile/lib/features/auth/presentation/pages/login.dart
@@ -4,7 +4,6 @@ import 'package:twoaxis_finance/core/widgets/themed_input_field.dart';
 import 'package:twoaxis_finance/features/auth/domain/auth_repository.dart';
 import 'package:twoaxis_finance/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:twoaxis_finance/features/auth/presentation/pages/forget_password.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 
@@ -58,7 +57,7 @@ class _LoginPageState extends State<LoginPage> {
                   height: MediaQuery.of(context).size.height,
                   decoration: BoxDecoration(
                     gradient: RadialGradient(
-                      colors: [darkTheme.secondary, Colors.transparent],
+                      colors: [Theme.of(context).colorScheme.secondary, Colors.transparent],
                       radius: 1,
                       center: Alignment.topCenter,
                     ),

--- a/mobile/lib/features/auth/presentation/pages/signup.dart
+++ b/mobile/lib/features/auth/presentation/pages/signup.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:twoaxis_finance/core/widgets/primary_button.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -32,7 +31,7 @@ class _SignupPageState extends State<SignupPage> {
                 .height, // Extends beyond the App Bar
             decoration: BoxDecoration(
               gradient: RadialGradient(
-                colors: [darkTheme.secondary, Colors.transparent],
+                colors: [Theme.of(context).colorScheme.secondary, Colors.transparent],
                 radius: 1,
                 center: Alignment.topCenter,
               ),

--- a/mobile/lib/features/balances/presentation/pages/balances.dart
+++ b/mobile/lib/features/balances/presentation/pages/balances.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/balances/domain/entities/balance.dart';
 import 'package:twoaxis_finance/features/balances/presentation/bloc/balances_bloc.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -26,7 +25,7 @@ class _BalancesPageState extends State<BalancesPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Balances"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [const BalancesActionButton()],
       ),
       body: Column(
@@ -87,7 +86,7 @@ class _BalancesPageState extends State<BalancesPage> {
                               child: Text(
                                   formatMoneyWithContext(context, item.value),
                                   style: TextStyle(
-                                      color: darkTheme.surfaceTint,
+                                      color: Theme.of(context).colorScheme.surfaceTint,
                                       fontSize: 15)),
                             )),
                         Expanded(
@@ -230,7 +229,7 @@ class _BalancesPageState extends State<BalancesPage> {
                   );
                 },
                 separatorBuilder: (BuildContext context, int index) {
-                  return Divider(color: darkTheme.surfaceContainer, height: 1);
+                  return Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                 },
               );
             }),

--- a/mobile/lib/features/bills/presentation/pages/bill_details.dart
+++ b/mobile/lib/features/bills/presentation/pages/bill_details.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class BillDetails extends StatefulWidget {
   const BillDetails({super.key, required this.index, required this.bill});
@@ -46,7 +45,7 @@ class _BillDetailsState extends State<BillDetails> {
                     Text(
                       formatMoneyWithContext(context, widget.bill.value),
                       style: TextStyle(
-                        color: darkTheme.primary,
+                        color: Theme.of(context).colorScheme.primary,
                         fontSize: 20,
                       ),
                     ),

--- a/mobile/lib/features/bills/presentation/pages/bill_payment.dart
+++ b/mobile/lib/features/bills/presentation/pages/bill_payment.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -86,7 +85,7 @@ class _BillPaymentState extends State<BillPayment> {
                               Icon(
                                 Icons.edit_document,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),
@@ -105,7 +104,7 @@ class _BillPaymentState extends State<BillPayment> {
                                   initialSelection: -1,
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,
@@ -152,7 +151,7 @@ class _BillPaymentState extends State<BillPayment> {
                                     width: 30,
                                     height: 30,
                                     decoration: BoxDecoration(
-                                        color: addToBudget ? darkTheme.primary : darkTheme.surfaceContainer,
+                                        color: addToBudget ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.surfaceContainer,
                                         borderRadius: BorderRadius.circular(5)
                                     ),
                                     child: addToBudget ? Icon(Icons.check) : null,

--- a/mobile/lib/features/bills/presentation/pages/bills.dart
+++ b/mobile/lib/features/bills/presentation/pages/bills.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/bills/presentation/pages/bill_details.d
 import 'package:twoaxis_finance/features/bills/presentation/widgets/bills_action_button.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,7 +20,7 @@ class _BillsPageState extends State<BillsPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Bills"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [BillsActionButton()],
       ),
       body: Column(
@@ -92,7 +91,7 @@ class _BillsPageState extends State<BillsPage> {
                               Text(
                                 formatMoneyWithContext(context, item.value),
                                 style: TextStyle(
-                                  color: darkTheme.primary,
+                                  color: Theme.of(context).colorScheme.primary,
                                   fontSize: 15,
                                 ),
                               ),
@@ -106,7 +105,7 @@ class _BillsPageState extends State<BillsPage> {
                   },
                   separatorBuilder: (BuildContext context, int index) {
                     return Divider(
-                        color: darkTheme.surfaceContainer, height: 1);
+                        color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                   },
                 );
               },

--- a/mobile/lib/features/bills/presentation/pages/bills_add.dart
+++ b/mobile/lib/features/bills/presentation/pages/bills_add.dart
@@ -1,7 +1,6 @@
 import 'package:twoaxis_finance/features/bills/domain/entities/bill.dart';
 import 'package:twoaxis_finance/features/bills/presentation/bloc/bills_bloc.dart';
 import 'package:twoaxis_finance/core/widgets/themed_input_field.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -80,7 +79,7 @@ class _BillsAddItemState extends State<BillsAddItem> {
                               Icon(
                                 Icons.edit_document,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),

--- a/mobile/lib/features/budget/presentation/pages/budget.dart
+++ b/mobile/lib/features/budget/presentation/pages/budget.dart
@@ -1,7 +1,6 @@
 import 'package:twoaxis_finance/features/budget/presentation/pages/budget_setup.dart';
 import 'package:twoaxis_finance/core/widgets/primary_button.dart';
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -18,7 +17,7 @@ class BudgetPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Budget"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       ),
       body: SafeArea(
         child: Padding(
@@ -71,7 +70,7 @@ class BudgetPage extends StatelessWidget {
                             CircularProgressIndicator(
                               value: percent > 1.0 ? 1.0 : percent,
                               strokeWidth: 100,
-                              backgroundColor: darkTheme.surfaceBright,
+                              backgroundColor: Theme.of(context).colorScheme.surfaceBright,
                               color: percent < 0.75
                                   ? Colors.green
                                   : percent < 1

--- a/mobile/lib/features/budget/presentation/pages/budget_setup.dart
+++ b/mobile/lib/features/budget/presentation/pages/budget_setup.dart
@@ -5,7 +5,6 @@ import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/widgets/primary_button.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
@@ -90,7 +89,7 @@ class _BudgetSetupState extends State<BudgetSetup> {
                               Icon(
                                 Icons.money_off_csred,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),

--- a/mobile/lib/features/dashboard/presentation/pages/dashboard.dart
+++ b/mobile/lib/features/dashboard/presentation/pages/dashboard.dart
@@ -1,3 +1,4 @@
+import 'package:twoaxis_finance/app/theme_cubit.dart';
 import 'package:twoaxis_finance/features/dashboard/presentation/widgets/dashboard_button.dart';
 import 'package:twoaxis_finance/features/transactions/domain/transaction_type.dart';
 import 'package:twoaxis_finance/features/transactions/presentation/bloc/transactions_bloc.dart';
@@ -26,23 +27,26 @@ class _DashboardPageState extends State<DashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<UserCubit, UserState>(
-      builder: (context, userState) {
+    return BlocBuilder<UserCubit, UserState>(builder: (context, userState) {
+      var user = (userState as UserStateAuthenticated).user;
 
-        if(userState is !UserStateAuthenticated) return const SizedBox();
-
+      return BlocBuilder<ThemeCubit, ThemeMode>(builder: (context, mode) {
         return Stack(
           children: [
-            Container(
-              height: 500,
-              decoration: BoxDecoration(
-                gradient: RadialGradient(
-                  colors: [Theme.of(context).colorScheme.primary, Colors.transparent],
-                  radius: 1,
-                  center: Alignment.topCenter,
+            if (mode == ThemeMode.dark)
+              Container(
+                height: 500,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    colors: [
+                      Theme.of(context).colorScheme.primary,
+                      Colors.transparent
+                    ],
+                    radius: 1,
+                    center: Alignment.topCenter,
+                  ),
                 ),
               ),
-            ),
             Container(
               padding: const EdgeInsets.all(20),
               child: Column(
@@ -68,7 +72,9 @@ class _DashboardPageState extends State<DashboardPage> {
                                   width: 120,
                                   height: 40,
                                   decoration: BoxDecoration(
-                                    color: Theme.of(context).colorScheme.surfaceContainer,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceContainer,
                                     borderRadius: BorderRadius.circular(5),
                                   ),
                                 ),
@@ -77,10 +83,15 @@ class _DashboardPageState extends State<DashboardPage> {
                               Text(
                                 formatMoneyWithContext(
                                     context,
-                                    userState.user.balances.fold<double>(
-                                        0, (sum, balance) => sum + balance.value)),
-                                style: const TextStyle(
-                                    fontWeight: FontWeight.bold, fontSize: 40),
+                                    user.balances.fold<double>(0,
+                                        (sum, balance) => sum + balance.value)),
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 40,
+                                  color: mode == ThemeMode.dark
+                                      ? Theme.of(context).colorScheme.onSurface
+                                      : Theme.of(context).colorScheme.primary,
+                                ),
                               ),
                             IconButton(
                               onPressed: () {
@@ -91,7 +102,11 @@ class _DashboardPageState extends State<DashboardPage> {
                               color: Colors.white,
                               icon: Icon(isHidden
                                   ? Icons.visibility_outlined
-                                  : Icons.visibility_off_outlined),
+                                  : Icons.visibility_off_outlined,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurface,
+                              ),
                             ),
                           ],
                         ),
@@ -124,7 +139,7 @@ class _DashboardPageState extends State<DashboardPage> {
                                             decoration: BoxDecoration(
                                               color: Colors.grey[300],
                                               borderRadius:
-                                              BorderRadius.circular(2),
+                                                  BorderRadius.circular(2),
                                             ),
                                           ),
                                           const SizedBox(
@@ -164,7 +179,8 @@ class _DashboardPageState extends State<DashboardPage> {
                                 Navigator.push(
                                     context,
                                     MaterialPageRoute(
-                                        builder: (context) => const AnalyticsPage()));
+                                        builder: (context) =>
+                                            const AnalyticsPage()));
                               },
                             ),
                             DashboardButton(
@@ -174,7 +190,8 @@ class _DashboardPageState extends State<DashboardPage> {
                                 Navigator.push(
                                     context,
                                     MaterialPageRoute(
-                                        builder: (context) => const BudgetPage()));
+                                        builder: (context) =>
+                                            const BudgetPage()));
                               },
                             ),
                           ],
@@ -198,9 +215,9 @@ class _DashboardPageState extends State<DashboardPage> {
                       children: [
                         Expanded(
                             child: Text(
-                              "Recent Transactions",
-                              style: TextStyle(fontSize: 15),
-                            )),
+                          "Recent Transactions",
+                          style: TextStyle(fontSize: 15),
+                        )),
                         Icon(Icons.arrow_forward_ios)
                       ],
                     ),
@@ -215,11 +232,13 @@ class _DashboardPageState extends State<DashboardPage> {
                           return const Center(
                             child: CircularProgressIndicator(),
                           );
-                        } else if (transactionsState is TransactionsStateError) {
+                        } else if (transactionsState
+                            is TransactionsStateError) {
                           return Center(
                             child: Text(transactionsState.message),
                           );
-                        } else if (transactionsState is TransactionsStateLoaded) {
+                        } else if (transactionsState
+                            is TransactionsStateLoaded) {
                           if (transactionsState.transactions.isEmpty) {
                             return Center(
                               child: Column(
@@ -248,9 +267,10 @@ class _DashboardPageState extends State<DashboardPage> {
                           }
                           return ListView.separated(
                             padding: EdgeInsets.zero,
-                            itemCount: transactionsState.transactions.length <= 30
-                                ? transactionsState.transactions.length
-                                : 30,
+                            itemCount:
+                                transactionsState.transactions.length <= 30
+                                    ? transactionsState.transactions.length
+                                    : 30,
                             itemBuilder: (context, index) {
                               var item = transactionsState.transactions[index];
                               return Row(
@@ -259,17 +279,18 @@ class _DashboardPageState extends State<DashboardPage> {
                                   Container(
                                     padding: const EdgeInsets.all(10),
                                     decoration: BoxDecoration(
-                                        color: Theme.of(context).colorScheme.surfaceBright,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceBright,
                                         borderRadius:
-                                        BorderRadius.circular(10)),
+                                            BorderRadius.circular(10)),
                                     child: Icon(
                                       getCategoryIcon(
                                         item.category,
                                         defaultIcon:
-                                        item.type ==
-                                            TransactionType.expense
-                                            ? Icons.payments_rounded
-                                            : Icons.file_download_rounded,
+                                            item.type == TransactionType.expense
+                                                ? Icons.payments_rounded
+                                                : Icons.file_download_rounded,
                                       ),
                                       size: 25,
                                     ),
@@ -277,7 +298,7 @@ class _DashboardPageState extends State<DashboardPage> {
                                   Expanded(
                                     child: Column(
                                       crossAxisAlignment:
-                                      CrossAxisAlignment.start,
+                                          CrossAxisAlignment.start,
                                       children: [
                                         Text(item.name),
                                         Text(
@@ -289,17 +310,17 @@ class _DashboardPageState extends State<DashboardPage> {
                                       ],
                                     ),
                                   ),
-                                  if (item.type ==
-                                      TransactionType.expense)
+                                  if (item.type == TransactionType.expense)
                                     Text(
                                       "-${formatMoneyWithContext(context, item.amount)}",
                                       style: TextStyle(
-                                          color: Theme.of(context).colorScheme.primary,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary,
                                           fontSize: 17,
                                           fontWeight: FontWeight.bold),
                                     )
-                                  else if (item.type ==
-                                      TransactionType.income)
+                                  else if (item.type == TransactionType.income)
                                     Text(
                                       "+${formatMoneyWithContext(context, item.amount)}",
                                       style: const TextStyle(
@@ -313,7 +334,10 @@ class _DashboardPageState extends State<DashboardPage> {
                             separatorBuilder:
                                 (BuildContext context, int index) {
                               return Divider(
-                                  color: Theme.of(context).colorScheme.surfaceBright, height: 20);
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .surfaceBright,
+                                  height: 20);
                             },
                           );
                         }
@@ -327,7 +351,7 @@ class _DashboardPageState extends State<DashboardPage> {
             )
           ],
         );
-      }
-    );
+      });
+    });
   }
 }

--- a/mobile/lib/features/dashboard/presentation/pages/dashboard.dart
+++ b/mobile/lib/features/dashboard/presentation/pages/dashboard.dart
@@ -8,7 +8,6 @@ import 'package:twoaxis_finance/features/budget/presentation/pages/budget.dart';
 import 'package:twoaxis_finance/features/quick_add/presentation/pages/quick_add_expense.dart';
 import 'package:twoaxis_finance/features/quick_add/presentation/pages/quick_add_income.dart';
 import 'package:twoaxis_finance/features/transactions/presentation/pages/transactions.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/util/get_category_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -38,7 +37,7 @@ class _DashboardPageState extends State<DashboardPage> {
               height: 500,
               decoration: BoxDecoration(
                 gradient: RadialGradient(
-                  colors: [darkTheme.primary, Colors.transparent],
+                  colors: [Theme.of(context).colorScheme.primary, Colors.transparent],
                   radius: 1,
                   center: Alignment.topCenter,
                 ),
@@ -69,7 +68,7 @@ class _DashboardPageState extends State<DashboardPage> {
                                   width: 120,
                                   height: 40,
                                   decoration: BoxDecoration(
-                                    color: darkTheme.surfaceContainer,
+                                    color: Theme.of(context).colorScheme.surfaceContainer,
                                     borderRadius: BorderRadius.circular(5),
                                   ),
                                 ),
@@ -260,7 +259,7 @@ class _DashboardPageState extends State<DashboardPage> {
                                   Container(
                                     padding: const EdgeInsets.all(10),
                                     decoration: BoxDecoration(
-                                        color: darkTheme.surfaceBright,
+                                        color: Theme.of(context).colorScheme.surfaceBright,
                                         borderRadius:
                                         BorderRadius.circular(10)),
                                     child: Icon(
@@ -295,7 +294,7 @@ class _DashboardPageState extends State<DashboardPage> {
                                     Text(
                                       "-${formatMoneyWithContext(context, item.amount)}",
                                       style: TextStyle(
-                                          color: darkTheme.primary,
+                                          color: Theme.of(context).colorScheme.primary,
                                           fontSize: 17,
                                           fontWeight: FontWeight.bold),
                                     )
@@ -314,7 +313,7 @@ class _DashboardPageState extends State<DashboardPage> {
                             separatorBuilder:
                                 (BuildContext context, int index) {
                               return Divider(
-                                  color: darkTheme.surfaceBright, height: 20);
+                                  color: Theme.of(context).colorScheme.surfaceBright, height: 20);
                             },
                           );
                         }

--- a/mobile/lib/features/dashboard/presentation/widgets/dashboard_button.dart
+++ b/mobile/lib/features/dashboard/presentation/widgets/dashboard_button.dart
@@ -18,8 +18,8 @@ class DashboardButton extends StatelessWidget {
             style: ElevatedButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
               shape: const CircleBorder(),
-              elevation: 6, // Adjust for shadow depth
-              padding: const EdgeInsets.all(16), // Ensures circular shape
+              elevation: 6,
+              padding: const EdgeInsets.all(16),
             ),
             child: Icon(
               icon,
@@ -31,7 +31,7 @@ class DashboardButton extends StatelessWidget {
             textAlign: TextAlign.center,
             softWrap: true,
             style: TextStyle(
-              color: Theme.of(context).colorScheme.onPrimary
+              color: Theme.of(context).colorScheme.onSurface
             ),
           ),
         ],

--- a/mobile/lib/features/dashboard/presentation/widgets/dashboard_button.dart
+++ b/mobile/lib/features/dashboard/presentation/widgets/dashboard_button.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 
 class DashboardButton extends StatelessWidget {
@@ -17,7 +16,7 @@ class DashboardButton extends StatelessWidget {
           ElevatedButton(
             onPressed: onPressed,
             style: ElevatedButton.styleFrom(
-              backgroundColor: darkTheme.surfaceContainer,
+              backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
               shape: const CircleBorder(),
               elevation: 6, // Adjust for shadow depth
               padding: const EdgeInsets.all(16), // Ensures circular shape
@@ -32,7 +31,7 @@ class DashboardButton extends StatelessWidget {
             textAlign: TextAlign.center,
             softWrap: true,
             style: TextStyle(
-              color: darkTheme.onPrimary
+              color: Theme.of(context).colorScheme.onPrimary
             ),
           ),
         ],

--- a/mobile/lib/features/income/presentation/pages/income.dart
+++ b/mobile/lib/features/income/presentation/pages/income.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/income/presentation/widgets/income_acti
 import 'package:twoaxis_finance/features/income/presentation/pages/income_details.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,7 +20,7 @@ class _IncomePageState extends State<IncomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Income"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [IncomeActionButton()],
       ),
       body: Column(
@@ -88,7 +87,7 @@ class _IncomePageState extends State<IncomePage> {
                                 formatMoneyWithContext(
                                     context, item.value),
                                 style: TextStyle(
-                                  color: darkTheme.primary,
+                                  color: Theme.of(context).colorScheme.primary,
                                   fontSize: 15,
                                 ),
                               ),
@@ -102,7 +101,7 @@ class _IncomePageState extends State<IncomePage> {
                   },
                   separatorBuilder: (BuildContext context, int index) {
                     return Divider(
-                        color: darkTheme.surfaceContainer, height: 1);
+                        color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                   },
                 );
               },

--- a/mobile/lib/features/income/presentation/pages/income_details.dart
+++ b/mobile/lib/features/income/presentation/pages/income_details.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class IncomeDetails extends StatefulWidget {
   const IncomeDetails({super.key, required this.index, required this.income});
@@ -46,7 +45,7 @@ class _IncomeDetailsState extends State<IncomeDetails> {
                     Text(
                       formatMoneyWithContext(context, widget.income.value),
                       style: TextStyle(
-                        color: darkTheme.primary,
+                        color: Theme.of(context).colorScheme.primary,
                         fontSize: 20,
                       ),
                     ),

--- a/mobile/lib/features/income/presentation/pages/income_payout.dart
+++ b/mobile/lib/features/income/presentation/pages/income_payout.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -95,7 +94,7 @@ class _IncomePayoutState extends State<IncomePayout> {
                                       : "Add a balance first",
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,

--- a/mobile/lib/features/info/presentation/pages/info.dart
+++ b/mobile/lib/features/info/presentation/pages/info.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 
 class InfoPage extends StatelessWidget {
@@ -11,33 +10,33 @@ class InfoPage extends StatelessWidget {
           title: const Text(
             "About",
           ),
-          backgroundColor: darkTheme.surfaceContainer,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         ),
         body: ListView(
           children: [
             ListTile(
               title: Text("Version",
-                  style: TextStyle(color: darkTheme.onSurfaceVariant)),
+                  style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
               subtitle: Text("1.2.1",
-                  style: TextStyle(color: darkTheme.onSurfaceVariant)),
-              leading: Icon(Icons.build, color: darkTheme.onSurfaceVariant),
+                  style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+              leading: Icon(Icons.build, color: Theme.of(context).colorScheme.onSurfaceVariant),
               onTap: () {},
             ),
-            Divider(color: darkTheme.surfaceContainer, height: 1),
+            Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1),
             ListTile(
               title: Text("Build Number",
-                  style: TextStyle(color: darkTheme.onSurfaceVariant)),
+                  style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
               subtitle: Text("17",
-                  style: TextStyle(color: darkTheme.onSurfaceVariant)),
-              leading: Icon(Icons.build, color: darkTheme.onSurfaceVariant),
+                  style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+              leading: Icon(Icons.build, color: Theme.of(context).colorScheme.onSurfaceVariant),
               onTap: () {},
             ),
-            Divider(color: darkTheme.surfaceContainer, height: 1),
+            Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1),
             const SizedBox(height: 30),
             Text(
               "(c) ${DateTime.now().year} TwoAxis. All Rights Reserved.",
               textAlign: TextAlign.center,
-              style: TextStyle(color: darkTheme.onSurfaceVariant),
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
           ],
         ));

--- a/mobile/lib/features/liabilities/presentation/pages/liabilities.dart
+++ b/mobile/lib/features/liabilities/presentation/pages/liabilities.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/liabilities/presentation/widgets/liabil
 import 'package:twoaxis_finance/features/liabilities/presentation/pages/liability_details.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,7 +20,7 @@ class _LiabilitiesPageState extends State<LiabilitiesPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Liabilities"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [LiabilitiesActionButton()],
       ),
       body: Column(
@@ -87,7 +86,7 @@ class _LiabilitiesPageState extends State<LiabilitiesPage> {
                             Text(
                               formatMoneyWithContext(context, item.value),
                               style: TextStyle(
-                                  color: darkTheme.surfaceTint, fontSize: 15),
+                                  color: Theme.of(context).colorScheme.surfaceTint, fontSize: 15),
                             ),
                             SizedBox(width: 10),
                             Icon(Icons.arrow_forward_ios, size: 15)
@@ -98,7 +97,7 @@ class _LiabilitiesPageState extends State<LiabilitiesPage> {
                   );
                 },
                 separatorBuilder: (BuildContext context, int index) {
-                  return Divider(color: darkTheme.surfaceContainer, height: 1);
+                  return Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                 },
               );
             }),

--- a/mobile/lib/features/liabilities/presentation/pages/liabilities_add.dart
+++ b/mobile/lib/features/liabilities/presentation/pages/liabilities_add.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/liabilities/domain/entities/liability.d
 import 'package:twoaxis_finance/features/liabilities/presentation/bloc/liabilities_bloc.dart';
 import 'package:twoaxis_finance/features/transactions/presentation/bloc/transactions_bloc.dart';
 import 'package:twoaxis_finance/features/transactions/domain/transaction_type.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -82,7 +81,7 @@ class _LiabilitiesAddState extends State<LiabilitiesAdd> {
                               Icon(
                                 Icons.card_travel,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),

--- a/mobile/lib/features/liabilities/presentation/pages/liability_details.dart
+++ b/mobile/lib/features/liabilities/presentation/pages/liability_details.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class LiabilityDetails extends StatefulWidget {
   const LiabilityDetails({super.key, required this.index, required this.liability});
@@ -46,7 +45,7 @@ class _LiabilityDetailsState extends State<LiabilityDetails> {
                     Text(
                       formatMoneyWithContext(context, widget.liability.value),
                       style: TextStyle(
-                        color: darkTheme.primary,
+                        color: Theme.of(context).colorScheme.primary,
                         fontSize: 20,
                       ),
                     ),

--- a/mobile/lib/features/liabilities/presentation/pages/liability_payment.dart
+++ b/mobile/lib/features/liabilities/presentation/pages/liability_payment.dart
@@ -1,5 +1,4 @@
 import 'package:twoaxis_finance/core/widgets/themed_input_field.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -86,7 +85,7 @@ class _LiabilityPaymentState extends State<LiabilityPayment> {
                               Icon(
                                 Icons.card_travel,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),
@@ -114,7 +113,7 @@ class _LiabilityPaymentState extends State<LiabilityPayment> {
                                   initialSelection: -1,
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,

--- a/mobile/lib/features/money_flow/presentation/pages/money_flow.dart
+++ b/mobile/lib/features/money_flow/presentation/pages/money_flow.dart
@@ -1,7 +1,6 @@
 import 'package:twoaxis_finance/features/bills/presentation/pages/bills.dart';
 import 'package:twoaxis_finance/features/budget/presentation/widgets/budget_info.dart';
 import 'package:twoaxis_finance/features/liabilities/presentation/pages/liabilities.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -46,7 +45,7 @@ class MoneyFlowPage extends StatelessWidget {
                         height: 150,
                         width: 150,
                         decoration: BoxDecoration(
-                            color: darkTheme.surfaceContainer,
+                            color: Theme.of(context).colorScheme.surfaceContainer,
                             borderRadius: BorderRadius.circular(10)
                         ),
                         child: Column(
@@ -54,7 +53,7 @@ class MoneyFlowPage extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.center,
                           spacing: 10,
                           children: [
-                            Icon(Icons.edit_document, size: 50, color: darkTheme.primary,),
+                            Icon(Icons.edit_document, size: 50, color: Theme.of(context).colorScheme.primary,),
                             const Text("Bills", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),)
                           ],
                         ),
@@ -73,7 +72,7 @@ class MoneyFlowPage extends StatelessWidget {
                         height: 150,
                         width: 150,
                         decoration: BoxDecoration(
-                            color: darkTheme.surfaceContainer,
+                            color: Theme.of(context).colorScheme.surfaceContainer,
                             borderRadius: BorderRadius.circular(10)
                         ),
                         child: Column(
@@ -81,7 +80,7 @@ class MoneyFlowPage extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.center,
                           spacing: 10,
                           children: [
-                            Icon(Icons.card_travel, size: 50, color: darkTheme.primary,),
+                            Icon(Icons.card_travel, size: 50, color: Theme.of(context).colorScheme.primary,),
                             const Text("Liabilities", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),)
                           ],
                         ),
@@ -149,7 +148,7 @@ class MoneyFlowPage extends StatelessWidget {
                             CircularProgressIndicator(
                               value: percent > 1.0 ? 1.0 : percent,
                               strokeWidth: 100,
-                              backgroundColor: darkTheme.surfaceBright,
+                              backgroundColor: Theme.of(context).colorScheme.surfaceBright,
                               color: percent < 0.75
                                   ? Colors.green
                                   : percent < 1

--- a/mobile/lib/features/onboarding/pages/onboarding.dart
+++ b/mobile/lib/features/onboarding/pages/onboarding.dart
@@ -1,7 +1,6 @@
 import 'package:twoaxis_finance/core/widgets/primary_button.dart';
 import 'package:twoaxis_finance/features/auth/presentation/pages/login.dart';
 import 'package:twoaxis_finance/features/auth/presentation/pages/signup.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -27,7 +26,7 @@ class _OnboardingState extends State<Onboarding> {
                 .height, // Extends beyond the App Bar
             decoration: BoxDecoration(
               gradient: RadialGradient(
-                colors: [darkTheme.secondary, Colors.transparent],
+                colors: [Theme.of(context).colorScheme.secondary, Colors.transparent],
                 radius: 1,
                 center: Alignment.topCenter,
               ),
@@ -125,7 +124,7 @@ class _OnboardingState extends State<Onboarding> {
                     height: 50,
                     child: ElevatedButton(
                       style: ElevatedButton.styleFrom(
-                          backgroundColor: darkTheme.surfaceContainer,
+                          backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
                           shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(10)),
                           shadowColor: Colors.black,
@@ -138,7 +137,7 @@ class _OnboardingState extends State<Onboarding> {
                       },
                       child: Text(
                         "Create an account",
-                        style: TextStyle(color: darkTheme.onPrimary),
+                        style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
                       ),
                     ),
                   ),

--- a/mobile/lib/features/quick_add/presentation/pages/quick_add_expense.dart
+++ b/mobile/lib/features/quick_add/presentation/pages/quick_add_expense.dart
@@ -1,5 +1,4 @@
 import 'package:twoaxis_finance/core/widgets/themed_input_field.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/categories.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
@@ -147,7 +146,7 @@ class _QuickAddExpenseState extends State<QuickAddExpense> {
                               Icon(
                                 Icons.edit_document,
                                 size: 100,
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ],
                           ),
@@ -179,8 +178,8 @@ class _QuickAddExpenseState extends State<QuickAddExpense> {
                                             horizontal: 16, vertical: 10),
                                         decoration: BoxDecoration(
                                           color: isSelected
-                                              ? darkTheme.primary
-                                              : darkTheme.surfaceContainer,
+                                              ? Theme.of(context).colorScheme.primary
+                                              : Theme.of(context).colorScheme.surfaceContainer,
                                           borderRadius:
                                               BorderRadius.circular(20),
                                           border: isSelected
@@ -252,7 +251,7 @@ class _QuickAddExpenseState extends State<QuickAddExpense> {
                                   initialSelection: -1,
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,
@@ -310,8 +309,8 @@ class _QuickAddExpenseState extends State<QuickAddExpense> {
                                     height: 30,
                                     decoration: BoxDecoration(
                                         color: addToBudget
-                                            ? darkTheme.primary
-                                            : darkTheme.surfaceContainer,
+                                            ? Theme.of(context).colorScheme.primary
+                                            : Theme.of(context).colorScheme.surfaceContainer,
                                         borderRadius:
                                             BorderRadius.circular(5)),
                                     child: addToBudget

--- a/mobile/lib/features/quick_add/presentation/pages/quick_add_income.dart
+++ b/mobile/lib/features/quick_add/presentation/pages/quick_add_income.dart
@@ -1,5 +1,4 @@
 import 'package:twoaxis_finance/core/widgets/themed_input_field.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/categories.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
@@ -173,8 +172,8 @@ class _QuickAddIncomeState extends State<QuickAddIncome> {
                                             horizontal: 16, vertical: 10),
                                         decoration: BoxDecoration(
                                           color: isSelected
-                                              ? darkTheme.primary
-                                              : darkTheme.surfaceContainer,
+                                              ? Theme.of(context).colorScheme.primary
+                                              : Theme.of(context).colorScheme.surfaceContainer,
                                           borderRadius:
                                               BorderRadius.circular(20),
                                           border: isSelected
@@ -246,7 +245,7 @@ class _QuickAddIncomeState extends State<QuickAddIncome> {
                                   initialSelection: -1,
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,

--- a/mobile/lib/features/receivables/presentation/pages/receivable_details.dart
+++ b/mobile/lib/features/receivables/presentation/pages/receivable_details.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class ReceivableDetails extends StatefulWidget {
   const ReceivableDetails({super.key, required this.index, required this.receivable});
@@ -46,7 +45,7 @@ class _ReceivableDetailsState extends State<ReceivableDetails> {
                     Text(
                       formatMoneyWithContext(context, widget.receivable.value),
                       style: TextStyle(
-                        color: darkTheme.primary,
+                        color: Theme.of(context).colorScheme.primary,
                         fontSize: 20,
                       ),
                     ),

--- a/mobile/lib/features/receivables/presentation/pages/receivable_payout.dart
+++ b/mobile/lib/features/receivables/presentation/pages/receivable_payout.dart
@@ -1,4 +1,3 @@
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -114,7 +113,7 @@ class _ReceivablePayState extends State<ReceivablePay> {
                                   initialSelection: -1,
                                   inputDecorationTheme: InputDecorationTheme(
                                     filled: true,
-                                    fillColor: darkTheme.surfaceContainer,
+                                    fillColor: Theme.of(context).colorScheme.surfaceContainer,
                                     border: OutlineInputBorder(
                                       borderRadius: BorderRadius.circular(10),
                                       borderSide: BorderSide.none,

--- a/mobile/lib/features/receivables/presentation/pages/receivables.dart
+++ b/mobile/lib/features/receivables/presentation/pages/receivables.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/receivables/presentation/pages/receivab
 import 'package:twoaxis_finance/features/receivables/presentation/widgets/receivables_action_button.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_cubit.dart';
 import 'package:twoaxis_finance/features/user/presentation/bloc/user_state.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -21,7 +20,7 @@ class _ReceivablesPageState extends State<ReceivablesPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Receivables"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
         actions: [ReceivablesActionButton()],
       ),
       body: Column(
@@ -93,7 +92,7 @@ class _ReceivablesPageState extends State<ReceivablesPage> {
                               formatMoneyWithContext(
                                   context, item.value),
                               style: TextStyle(
-                                color: darkTheme.primary,
+                                color: Theme.of(context).colorScheme.primary,
                                 fontSize: 15,
                               ),
                             ),
@@ -106,7 +105,7 @@ class _ReceivablesPageState extends State<ReceivablesPage> {
                   );
                 },
                 separatorBuilder: (BuildContext context, int index) {
-                  return Divider(color: darkTheme.surfaceContainer, height: 1);
+                  return Divider(color: Theme.of(context).colorScheme.surfaceContainer, height: 1);
                 },
               );
             }),

--- a/mobile/lib/features/transactions/presentation/pages/transactions.dart
+++ b/mobile/lib/features/transactions/presentation/pages/transactions.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:twoaxis_finance/core/util/money_format.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 
 class TransactionsPage extends StatelessWidget {
   const TransactionsPage({super.key});
@@ -16,7 +15,7 @@ class TransactionsPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text("Transactions"),
-        backgroundColor: darkTheme.surfaceContainer,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       ),
       body: SafeArea(
         child: Padding(
@@ -125,7 +124,7 @@ class TransactionsPage extends StatelessWidget {
                                   Container(
                                     padding: EdgeInsets.all(10),
                                     decoration: BoxDecoration(
-                                        color: darkTheme.surfaceBright,
+                                        color: Theme.of(context).colorScheme.surfaceBright,
                                         borderRadius: BorderRadius.circular(10)),
                                     child: Icon(
                                       getCategoryIcon(
@@ -155,7 +154,7 @@ class TransactionsPage extends StatelessWidget {
                                     Text(
                                       "-${formatMoneyWithContext(context, tx.amount)}",
                                       style: TextStyle(
-                                          color: darkTheme.primary,
+                                          color: Theme.of(context).colorScheme.primary,
                                           fontSize: 17,
                                           fontWeight: FontWeight.bold),
                                     )
@@ -176,7 +175,7 @@ class TransactionsPage extends StatelessWidget {
                     );
                   },
                   separatorBuilder: (BuildContext context, int index) {
-                    return Divider(color: darkTheme.surfaceBright, height: 30);
+                    return Divider(color: Theme.of(context).colorScheme.surfaceBright, height: 30);
                   },
                 );
               }

--- a/mobile/lib/features/wallet/presentation/pages/wallet.dart
+++ b/mobile/lib/features/wallet/presentation/pages/wallet.dart
@@ -2,7 +2,6 @@ import 'package:twoaxis_finance/features/assets/presentation/pages/assets.dart';
 import 'package:twoaxis_finance/features/balances/presentation/pages/balances.dart';
 import 'package:twoaxis_finance/features/income/presentation/pages/income.dart';
 import 'package:twoaxis_finance/features/receivables/presentation/pages/receivables.dart';
-import 'package:twoaxis_finance/app/theme.dart';
 import 'package:twoaxis_finance/core/values/spaces.dart';
 import 'package:flutter/material.dart';
 
@@ -33,7 +32,7 @@ class Wallet extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(25),
                   decoration: BoxDecoration(
-                      color: darkTheme.surfaceContainer,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       borderRadius: BorderRadius.circular(10)),
                   child: Row(
                     spacing: 10,
@@ -76,7 +75,7 @@ class Wallet extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(25),
                   decoration: BoxDecoration(
-                      color: darkTheme.surfaceContainer,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       borderRadius: BorderRadius.circular(10)),
                   child: Row(
                     spacing: 10,
@@ -119,7 +118,7 @@ class Wallet extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(25),
                   decoration: BoxDecoration(
-                      color: darkTheme.surfaceContainer,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       borderRadius: BorderRadius.circular(10)),
                   child: Row(
                     spacing: 10,
@@ -162,7 +161,7 @@ class Wallet extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(25),
                   decoration: BoxDecoration(
-                      color: darkTheme.surfaceContainer,
+                      color: Theme.of(context).colorScheme.surfaceContainer,
                       borderRadius: BorderRadius.circular(10)),
                   child: Row(
                     spacing: 10,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -440,6 +448,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -448,6 +480,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -480,6 +520,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.20"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -637,6 +733,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_native_splash: ^2.4.7
   equatable: ^2.0.8
   rxdart: ^0.28.0
+  shared_preferences: ^2.5.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Implemented light mode for the mobile app.
- Created `ThemeCubit` for state management.
- Added `appLightTheme` and renamed `darkTheme` to `appDarkTheme` in `mobile/lib/app/theme.dart`.
- Refactored all UI components to use `Theme.of(context).colorScheme`.
- Updated `mobile/lib/app/app.dart` to provide `ThemeCubit` and use `BlocBuilder` for dynamic theme switching.
- Added a "Dark Mode" switch in `mobile/lib/features/account/presentation/pages/account.dart`.

---
*PR created automatically by Jules for task [5882496080063964428](https://jules.google.com/task/5882496080063964428) started by @Salint*